### PR TITLE
feat: add clux-coord crate for MCP-based agent coordination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "az"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,6 +877,21 @@ dependencies = [
  "wezterm-gui-subcommands",
  "wezterm-term",
  "winapi",
+]
+
+[[package]]
+name = "clux-coord"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "dirs",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1440,6 +1507,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,13 +1526,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -2595,6 +2683,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humansize"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2623,6 +2717,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -3430,6 +3525,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4120,6 +4221,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -4864,6 +4971,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5259,6 +5377,17 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
  "serde",
  "serde_core",
 ]
@@ -6267,6 +6396,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6305,6 +6435,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "bidi",
+  "crates/clux-coord",
   "bidi/generate",
   "strip-ansi-escapes",
   "sync-color-schemes",

--- a/crates/clux-coord/Cargo.toml
+++ b/crates/clux-coord/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "clux-coord"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+thiserror = "2"
+anyhow = "1"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
+axum = "0.8"
+rusqlite = { version = "0.32", features = ["bundled"] }
+dirs = "6"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }

--- a/crates/clux-coord/src/broker.rs
+++ b/crates/clux-coord/src/broker.rs
@@ -1,0 +1,435 @@
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use rusqlite::Connection;
+use tracing::info;
+
+use crate::error::{CoordError, Result};
+use crate::protocol::{PeerInfo, PeerMessage, TaskRequest, TaskStatus};
+
+/// SQLite-backed message broker for peer coordination.
+pub struct Broker {
+    conn: Mutex<Connection>,
+}
+
+impl Broker {
+    /// Create a new broker with the database at the given path.
+    pub fn open(db_path: &PathBuf) -> Result<Self> {
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let conn = Connection::open(db_path)?;
+        let broker = Self {
+            conn: Mutex::new(conn),
+        };
+        broker.init_schema()?;
+        info!(?db_path, "Coordination broker initialized");
+        Ok(broker)
+    }
+
+    /// Create an in-memory broker (useful for testing).
+    pub fn in_memory() -> Result<Self> {
+        let conn = Connection::open_in_memory()?;
+        let broker = Self {
+            conn: Mutex::new(conn),
+        };
+        broker.init_schema()?;
+        Ok(broker)
+    }
+
+    fn init_schema(&self) -> Result<()> {
+        let conn = self.conn.lock().expect("broker lock poisoned");
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS peers (
+                peer_id    TEXT PRIMARY KEY,
+                pane_id    INTEGER NOT NULL,
+                cwd        TEXT,
+                status_text TEXT,
+                last_heartbeat INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+            );
+
+            CREATE TABLE IF NOT EXISTS messages (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                from_peer  TEXT NOT NULL,
+                to_peer    TEXT,
+                body       TEXT NOT NULL,
+                timestamp  INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_messages_to_peer
+                ON messages(to_peer);
+
+            CREATE TABLE IF NOT EXISTS tasks (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                description TEXT NOT NULL,
+                status      TEXT NOT NULL DEFAULT 'pending',
+                requester   TEXT NOT NULL,
+                assignee    TEXT,
+                created_at  INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+            );",
+        )?;
+        Ok(())
+    }
+
+    // --- Peer operations ---
+
+    /// Register or update a peer.
+    pub fn register_peer(&self, peer_id: &str, pane_id: u64) -> Result<()> {
+        let conn = self.conn.lock().expect("broker lock poisoned");
+        conn.execute(
+            "INSERT INTO peers (peer_id, pane_id, last_heartbeat)
+             VALUES (?1, ?2, strftime('%s', 'now'))
+             ON CONFLICT(peer_id) DO UPDATE SET
+                pane_id = excluded.pane_id,
+                last_heartbeat = strftime('%s', 'now')",
+            rusqlite::params![peer_id, pane_id],
+        )?;
+        info!(peer_id, pane_id, "Peer registered");
+        Ok(())
+    }
+
+    /// Remove a peer.
+    pub fn unregister_peer(&self, peer_id: &str) -> Result<()> {
+        let conn = self.conn.lock().expect("broker lock poisoned");
+        conn.execute("DELETE FROM peers WHERE peer_id = ?1", [peer_id])?;
+        info!(peer_id, "Peer unregistered");
+        Ok(())
+    }
+
+    /// Update heartbeat timestamp for a peer.
+    pub fn heartbeat(&self, peer_id: &str) -> Result<()> {
+        let conn = self.conn.lock().expect("broker lock poisoned");
+        conn.execute(
+            "UPDATE peers SET last_heartbeat = strftime('%s', 'now') WHERE peer_id = ?1",
+            [peer_id],
+        )?;
+        Ok(())
+    }
+
+    /// List all peers (optionally filter to those active within `max_age_secs`).
+    pub fn list_peers(&self, max_age_secs: Option<i64>) -> Result<Vec<PeerInfo>> {
+        let conn = self.conn.lock().expect("broker lock poisoned");
+        let mut stmt = if let Some(age) = max_age_secs {
+            let mut s = conn.prepare(
+                "SELECT peer_id, pane_id, cwd, status_text, last_heartbeat
+                 FROM peers
+                 WHERE last_heartbeat >= strftime('%s', 'now') - ?1
+                 ORDER BY pane_id",
+            )?;
+            let rows = s
+                .query_map([age], map_peer_row)?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            return Ok(rows);
+        } else {
+            conn.prepare(
+                "SELECT peer_id, pane_id, cwd, status_text, last_heartbeat
+                 FROM peers ORDER BY pane_id",
+            )?
+        };
+        let rows = stmt
+            .query_map([], map_peer_row)?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// Set status text for a peer.
+    pub fn set_status(&self, peer_id: &str, text: &str) -> Result<()> {
+        let conn = self.conn.lock().expect("broker lock poisoned");
+        let updated = conn.execute(
+            "UPDATE peers SET status_text = ?2, last_heartbeat = strftime('%s', 'now')
+             WHERE peer_id = ?1",
+            rusqlite::params![peer_id, text],
+        )?;
+        if updated == 0 {
+            return Err(CoordError::PeerNotFound(peer_id.to_string()));
+        }
+        Ok(())
+    }
+
+    /// Set CWD for a peer.
+    pub fn set_cwd(&self, peer_id: &str, cwd: &str) -> Result<()> {
+        let conn = self.conn.lock().expect("broker lock poisoned");
+        conn.execute(
+            "UPDATE peers SET cwd = ?2 WHERE peer_id = ?1",
+            rusqlite::params![peer_id, cwd],
+        )?;
+        Ok(())
+    }
+
+    // --- Message operations ---
+
+    /// Send a message to a specific peer (or broadcast if `to_peer` is `None`).
+    pub fn send_message(&self, msg: &PeerMessage) -> Result<i64> {
+        let conn = self.conn.lock().expect("broker lock poisoned");
+        let body_json = serde_json::to_string(&msg.body)?;
+        conn.execute(
+            "INSERT INTO messages (from_peer, to_peer, body)
+             VALUES (?1, ?2, ?3)",
+            rusqlite::params![msg.from_peer, msg.to_peer, body_json],
+        )?;
+        Ok(conn.last_insert_rowid())
+    }
+
+    /// Read messages for a peer, optionally since a given message ID.
+    pub fn read_messages(&self, peer_id: &str, since_id: Option<i64>) -> Result<Vec<PeerMessage>> {
+        let conn = self.conn.lock().expect("broker lock poisoned");
+        let since = since_id.unwrap_or(0);
+        let mut stmt = conn.prepare(
+            "SELECT id, from_peer, to_peer, body, timestamp
+             FROM messages
+             WHERE (to_peer = ?1 OR to_peer IS NULL)
+               AND id > ?2
+             ORDER BY id",
+        )?;
+        let rows = stmt
+            .query_map(rusqlite::params![peer_id, since], |row| {
+                let body_str: String = row.get(3)?;
+                let body: serde_json::Value =
+                    serde_json::from_str(&body_str).unwrap_or(serde_json::Value::Null);
+                Ok(PeerMessage {
+                    id: Some(row.get(0)?),
+                    from_peer: row.get(1)?,
+                    to_peer: row.get(2)?,
+                    body,
+                    timestamp: Some(row.get(4)?),
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// Broadcast a message to all peers.
+    pub fn broadcast(&self, from_peer: &str, body: &serde_json::Value) -> Result<i64> {
+        let msg = PeerMessage {
+            id: None,
+            from_peer: from_peer.to_string(),
+            to_peer: None,
+            body: body.clone(),
+            timestamp: None,
+        };
+        self.send_message(&msg)
+    }
+
+    // --- Task operations ---
+
+    /// Create a new task request.
+    pub fn create_task(&self, task: &TaskRequest) -> Result<i64> {
+        let conn = self.conn.lock().expect("broker lock poisoned");
+        conn.execute(
+            "INSERT INTO tasks (description, status, requester, assignee)
+             VALUES (?1, ?2, ?3, ?4)",
+            rusqlite::params![
+                task.description,
+                task.status.to_string(),
+                task.requester,
+                task.assignee,
+            ],
+        )?;
+        Ok(conn.last_insert_rowid())
+    }
+
+    /// List tasks, optionally filtered by assignee.
+    pub fn list_tasks(&self, assignee: Option<&str>) -> Result<Vec<TaskRequest>> {
+        let conn = self.conn.lock().expect("broker lock poisoned");
+        let mut tasks = Vec::new();
+        if let Some(assignee) = assignee {
+            let mut stmt = conn.prepare(
+                "SELECT id, description, status, requester, assignee, created_at
+                 FROM tasks WHERE assignee = ?1 ORDER BY id",
+            )?;
+            let rows = stmt.query_map([assignee], map_task_row)?;
+            for row in rows {
+                tasks.push(row?);
+            }
+        } else {
+            let mut stmt = conn.prepare(
+                "SELECT id, description, status, requester, assignee, created_at
+                 FROM tasks ORDER BY id",
+            )?;
+            let rows = stmt.query_map([], map_task_row)?;
+            for row in rows {
+                tasks.push(row?);
+            }
+        }
+        Ok(tasks)
+    }
+
+    /// Update task status.
+    pub fn update_task_status(&self, task_id: i64, status: TaskStatus) -> Result<()> {
+        let conn = self.conn.lock().expect("broker lock poisoned");
+        conn.execute(
+            "UPDATE tasks SET status = ?2 WHERE id = ?1",
+            rusqlite::params![task_id, status.to_string()],
+        )?;
+        Ok(())
+    }
+}
+
+fn map_peer_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<PeerInfo> {
+    Ok(PeerInfo {
+        peer_id: row.get(0)?,
+        pane_id: row.get(1)?,
+        cwd: row.get(2)?,
+        status_text: row.get(3)?,
+        last_heartbeat: row.get(4)?,
+    })
+}
+
+fn map_task_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TaskRequest> {
+    let status_str: String = row.get(2)?;
+    let status = status_str.parse().unwrap_or(TaskStatus::Pending);
+    Ok(TaskRequest {
+        id: Some(row.get(0)?),
+        description: row.get(1)?,
+        status,
+        requester: row.get(3)?,
+        assignee: row.get(4)?,
+        created_at: Some(row.get(5)?),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_broker() -> Broker {
+        Broker::in_memory().unwrap()
+    }
+
+    #[test]
+    fn register_and_list_peers() {
+        let broker = test_broker();
+        broker.register_peer("peer-1", 0).unwrap();
+        broker.register_peer("peer-2", 1).unwrap();
+        let peers = broker.list_peers(None).unwrap();
+        assert_eq!(peers.len(), 2);
+        assert_eq!(peers[0].peer_id, "peer-1");
+        assert_eq!(peers[1].pane_id, 1);
+    }
+
+    #[test]
+    fn unregister_peer() {
+        let broker = test_broker();
+        broker.register_peer("peer-1", 0).unwrap();
+        broker.unregister_peer("peer-1").unwrap();
+        let peers = broker.list_peers(None).unwrap();
+        assert!(peers.is_empty());
+    }
+
+    #[test]
+    fn set_and_read_status() {
+        let broker = test_broker();
+        broker.register_peer("peer-1", 0).unwrap();
+        broker.set_status("peer-1", "working on tests").unwrap();
+        let peers = broker.list_peers(None).unwrap();
+        assert_eq!(peers[0].status_text.as_deref(), Some("working on tests"));
+    }
+
+    #[test]
+    fn set_status_unknown_peer() {
+        let broker = test_broker();
+        let result = broker.set_status("unknown", "test");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn send_and_read_messages() {
+        let broker = test_broker();
+        broker.register_peer("a", 0).unwrap();
+        broker.register_peer("b", 1).unwrap();
+
+        let msg = PeerMessage {
+            id: None,
+            from_peer: "a".into(),
+            to_peer: Some("b".into()),
+            body: serde_json::json!({"text": "hello"}),
+            timestamp: None,
+        };
+        broker.send_message(&msg).unwrap();
+
+        let msgs = broker.read_messages("b", None).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].from_peer, "a");
+        assert_eq!(msgs[0].body["text"], "hello");
+
+        // Peer "a" should not see messages to "b"
+        let msgs_a = broker.read_messages("a", None).unwrap();
+        assert!(msgs_a.is_empty());
+    }
+
+    #[test]
+    fn broadcast_reaches_all() {
+        let broker = test_broker();
+        broker.register_peer("a", 0).unwrap();
+        broker.register_peer("b", 1).unwrap();
+
+        broker
+            .broadcast("a", &serde_json::json!({"text": "broadcast"}))
+            .unwrap();
+
+        // Broadcast (to_peer IS NULL) should be visible to both
+        let msgs_a = broker.read_messages("a", None).unwrap();
+        let msgs_b = broker.read_messages("b", None).unwrap();
+        assert_eq!(msgs_a.len(), 1);
+        assert_eq!(msgs_b.len(), 1);
+    }
+
+    #[test]
+    fn read_messages_since_id() {
+        let broker = test_broker();
+        broker.register_peer("a", 0).unwrap();
+
+        let id1 = broker.broadcast("a", &serde_json::json!({"n": 1})).unwrap();
+        broker.broadcast("a", &serde_json::json!({"n": 2})).unwrap();
+
+        let msgs = broker.read_messages("a", Some(id1)).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].body["n"], 2);
+    }
+
+    #[test]
+    fn create_and_list_tasks() {
+        let broker = test_broker();
+        broker.register_peer("a", 0).unwrap();
+
+        let task = TaskRequest {
+            id: None,
+            description: "run tests".into(),
+            status: TaskStatus::Pending,
+            requester: "a".into(),
+            assignee: Some("b".into()),
+            created_at: None,
+        };
+        let task_id = broker.create_task(&task).unwrap();
+        assert!(task_id > 0);
+
+        let all = broker.list_tasks(None).unwrap();
+        assert_eq!(all.len(), 1);
+
+        let for_b = broker.list_tasks(Some("b")).unwrap();
+        assert_eq!(for_b.len(), 1);
+
+        let for_c = broker.list_tasks(Some("c")).unwrap();
+        assert!(for_c.is_empty());
+    }
+
+    #[test]
+    fn update_task_status() {
+        let broker = test_broker();
+        let task = TaskRequest {
+            id: None,
+            description: "build".into(),
+            status: TaskStatus::Pending,
+            requester: "a".into(),
+            assignee: None,
+            created_at: None,
+        };
+        let id = broker.create_task(&task).unwrap();
+        broker
+            .update_task_status(id, TaskStatus::Completed)
+            .unwrap();
+
+        let tasks = broker.list_tasks(None).unwrap();
+        assert_eq!(tasks[0].status, TaskStatus::Completed);
+    }
+}

--- a/crates/clux-coord/src/detect.rs
+++ b/crates/clux-coord/src/detect.rs
@@ -1,0 +1,230 @@
+use std::path::{Path, PathBuf};
+
+use tracing::info;
+
+use crate::error::Result;
+
+/// Patterns that indicate Claude Code is running in a pane.
+/// Claude Code outputs its banner on startup.
+const DETECTION_PATTERNS: &[&str] = &[
+    "\u{256d}\u{2500}", // Claude Code TUI top border
+    "claude",           // claude command invocation
+];
+
+/// Minimum number of characters to buffer before attempting detection.
+const MIN_BUFFER_LEN: usize = 32;
+
+/// Tracks whether Claude Code has been detected in a pane's output.
+#[derive(Debug)]
+pub struct ClaudeDetector {
+    /// Rolling buffer of recent output text for pattern matching.
+    buffer: String,
+    /// Whether Claude Code has been detected in this pane.
+    pub detected: bool,
+    /// Whether the MCP config has been injected for this pane.
+    pub config_injected: bool,
+}
+
+impl ClaudeDetector {
+    pub fn new() -> Self {
+        Self {
+            buffer: String::with_capacity(256),
+            detected: false,
+            config_injected: false,
+        }
+    }
+
+    /// Feed terminal output text for detection.
+    /// Returns `true` if Claude Code was newly detected (first time).
+    pub fn feed(&mut self, text: &str) -> bool {
+        if self.detected {
+            return false;
+        }
+
+        self.buffer.push_str(text);
+
+        // Trim buffer to avoid unbounded growth
+        if self.buffer.len() > 1024 {
+            let start = self.buffer.len() - 512;
+            self.buffer = self.buffer[start..].to_string();
+        }
+
+        if self.buffer.len() < MIN_BUFFER_LEN {
+            return false;
+        }
+
+        let lower = self.buffer.to_lowercase();
+        for pattern in DETECTION_PATTERNS {
+            if lower.contains(pattern) {
+                self.detected = true;
+                info!(pattern, "Claude Code detected in pane output");
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Reset detection state (e.g., when a pane is reused).
+    pub fn reset(&mut self) {
+        self.buffer.clear();
+        self.detected = false;
+        self.config_injected = false;
+    }
+}
+
+impl Default for ClaudeDetector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct ClaudeSettings {
+    #[serde(rename = "mcpServers", default)]
+    mcp_servers: serde_json::Map<String, serde_json::Value>,
+    #[serde(flatten)]
+    other: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Inject MCP server configuration into `.claude/settings.local.json`.
+///
+/// If `cwd` is provided, writes to `{cwd}/.claude/settings.local.json`.
+/// Otherwise falls back to the user's home directory.
+pub fn inject_mcp_config(cwd: Option<&Path>, mcp_port: u16) -> Result<PathBuf> {
+    let base = if let Some(cwd) = cwd {
+        cwd.to_path_buf()
+    } else {
+        dirs::home_dir().unwrap_or_else(|| PathBuf::from("."))
+    };
+
+    let settings_dir = base.join(".claude");
+    std::fs::create_dir_all(&settings_dir)?;
+
+    let settings_path = settings_dir.join("settings.local.json");
+
+    // Read existing settings or start fresh
+    let mut settings: ClaudeSettings = if settings_path.exists() {
+        let content = std::fs::read_to_string(&settings_path)?;
+        serde_json::from_str(&content).unwrap_or_else(|_| ClaudeSettings {
+            mcp_servers: serde_json::Map::new(),
+            other: serde_json::Map::new(),
+        })
+    } else {
+        ClaudeSettings {
+            mcp_servers: serde_json::Map::new(),
+            other: serde_json::Map::new(),
+        }
+    };
+
+    // Add/update the clux-coord MCP server entry
+    let server_config = serde_json::json!({
+        "url": format!("http://127.0.0.1:{mcp_port}/mcp")
+    });
+    settings
+        .mcp_servers
+        .insert("clux-coord".to_string(), server_config);
+
+    let json = serde_json::to_string_pretty(&settings)?;
+    std::fs::write(&settings_path, json)?;
+
+    info!(?settings_path, "MCP config injected for Claude Code");
+    Ok(settings_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_claude_code_banner() {
+        let mut d = ClaudeDetector::new();
+        // Not enough data yet
+        assert!(!d.feed("short"));
+        assert!(!d.detected);
+
+        // Feed enough text with the pattern
+        assert!(
+            d.feed("some output before \u{256d}\u{2500} Claude Code v1.0 and more text after it")
+        );
+        assert!(d.detected);
+    }
+
+    #[test]
+    fn detect_claude_command() {
+        let mut d = ClaudeDetector::new();
+        assert!(d.feed("PS C:\\Users\\test> claude some-argument and more text here"));
+        assert!(d.detected);
+    }
+
+    #[test]
+    fn no_double_detection() {
+        let mut d = ClaudeDetector::new();
+        assert!(d.feed("running claude code in this terminal pane right now"));
+        // Second call should not re-detect
+        assert!(!d.feed("claude again"));
+    }
+
+    #[test]
+    fn reset_allows_redetection() {
+        let mut d = ClaudeDetector::new();
+        d.feed("running claude code in this terminal pane right now");
+        assert!(d.detected);
+        d.reset();
+        assert!(!d.detected);
+        assert!(d.feed("running claude code in this terminal pane right now"));
+    }
+
+    #[test]
+    fn inject_mcp_config_creates_file() {
+        let tmp = std::env::temp_dir().join("clux-test-inject");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let path = inject_mcp_config(Some(&tmp), 19836).unwrap();
+        assert!(path.exists());
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(
+            parsed["mcpServers"]["clux-coord"]["url"],
+            "http://127.0.0.1:19836/mcp"
+        );
+
+        std::fs::remove_dir_all(&tmp).unwrap();
+    }
+
+    #[test]
+    fn inject_mcp_config_preserves_existing() {
+        let tmp = std::env::temp_dir().join("clux-test-inject-existing");
+        let _ = std::fs::remove_dir_all(&tmp);
+        let claude_dir = tmp.join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+
+        // Write existing settings
+        let existing = serde_json::json!({
+            "mcpServers": {
+                "other-server": { "command": "other" }
+            },
+            "someKey": "someValue"
+        });
+        std::fs::write(
+            claude_dir.join("settings.local.json"),
+            serde_json::to_string_pretty(&existing).unwrap(),
+        )
+        .unwrap();
+
+        inject_mcp_config(Some(&tmp), 19836).unwrap();
+
+        let content = std::fs::read_to_string(claude_dir.join("settings.local.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+        // Both servers should exist
+        assert!(parsed["mcpServers"]["other-server"].is_object());
+        assert!(parsed["mcpServers"]["clux-coord"].is_object());
+        // Other keys preserved
+        assert_eq!(parsed["someKey"], "someValue");
+
+        std::fs::remove_dir_all(&tmp).unwrap();
+    }
+}

--- a/crates/clux-coord/src/error.rs
+++ b/crates/clux-coord/src/error.rs
@@ -1,0 +1,21 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CoordError {
+    #[error("database error: {0}")]
+    Database(#[from] rusqlite::Error),
+
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("peer not found: {0}")]
+    PeerNotFound(String),
+
+    #[error("server error: {0}")]
+    Server(String),
+}
+
+pub type Result<T> = std::result::Result<T, CoordError>;

--- a/crates/clux-coord/src/lib.rs
+++ b/crates/clux-coord/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod broker;
+pub mod detect;
+pub mod error;
+pub mod mcp_bridge;
+pub mod panel;
+pub mod peer;
+pub mod protocol;

--- a/crates/clux-coord/src/mcp_bridge.rs
+++ b/crates/clux-coord/src/mcp_bridge.rs
@@ -1,0 +1,495 @@
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::routing::post;
+use axum::{Json, Router};
+use tokio::sync::RwLock;
+use tracing::{error, info};
+
+use crate::broker::Broker;
+use crate::error::Result;
+use crate::protocol::{
+    JsonRpcRequest, JsonRpcResponse, McpToolInfo, PeerMessage, TaskRequest, TaskStatus,
+};
+
+/// Shared state accessible to all MCP request handlers.
+pub struct McpState {
+    pub broker: Arc<Broker>,
+    /// Pane context provider: maps `pane_id` to visible text content.
+    /// Updated by the main app whenever terminal buffers change.
+    pub pane_contexts: RwLock<HashMap<u64, String>>,
+}
+
+/// Start the MCP HTTP server on the given port.
+/// Returns the actual bound address.
+pub async fn start_server(state: Arc<McpState>, port: u16) -> Result<SocketAddr> {
+    let app = Router::new()
+        .route("/mcp", post(handle_mcp_request))
+        .with_state(state);
+
+    let addr: SocketAddr = ([127, 0, 0, 1], port).into();
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .map_err(|e| crate::error::CoordError::Server(e.to_string()))?;
+    let bound = listener
+        .local_addr()
+        .map_err(|e| crate::error::CoordError::Server(e.to_string()))?;
+
+    info!(%bound, "MCP server listening");
+
+    tokio::spawn(async move {
+        if let Err(e) = axum::serve(listener, app).await {
+            error!(%e, "MCP server error");
+        }
+    });
+
+    Ok(bound)
+}
+
+async fn handle_mcp_request(
+    axum::extract::State(state): axum::extract::State<Arc<McpState>>,
+    Json(req): Json<JsonRpcRequest>,
+) -> Json<JsonRpcResponse> {
+    tracing::debug!(method = %req.method, "MCP request received");
+    let response = match req.method.as_str() {
+        "initialize" => handle_initialize(&req),
+        "tools/list" => handle_tools_list(&req),
+        "tools/call" => handle_tools_call(&state, &req).await,
+        _ => JsonRpcResponse::error(req.id, -32601, format!("Method not found: {}", req.method)),
+    };
+    Json(response)
+}
+
+fn handle_initialize(req: &JsonRpcRequest) -> JsonRpcResponse {
+    JsonRpcResponse::success(
+        req.id.clone(),
+        serde_json::json!({
+            "protocolVersion": "2025-03-26",
+            "capabilities": {
+                "tools": {}
+            },
+            "serverInfo": {
+                "name": "clux-coord",
+                "version": env!("CARGO_PKG_VERSION")
+            }
+        }),
+    )
+}
+
+fn handle_tools_list(req: &JsonRpcRequest) -> JsonRpcResponse {
+    let tools = build_tool_definitions();
+    JsonRpcResponse::success(req.id.clone(), serde_json::json!({ "tools": tools }))
+}
+
+async fn handle_tools_call(state: &McpState, req: &JsonRpcRequest) -> JsonRpcResponse {
+    let tool_name = req.params.get("name").and_then(|v| v.as_str());
+    let args = req
+        .params
+        .get("arguments")
+        .cloned()
+        .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+
+    let Some(tool_name) = tool_name else {
+        return JsonRpcResponse::error(req.id.clone(), -32602, "Missing 'name' parameter");
+    };
+
+    let result = match tool_name {
+        "clux_list_peers" => tool_list_peers(state),
+        "clux_send_message" => tool_send_message(state, &args),
+        "clux_read_messages" => tool_read_messages(state, &args),
+        "clux_broadcast" => tool_broadcast(state, &args),
+        "clux_get_pane_context" => tool_get_pane_context(state, &args).await,
+        "clux_set_status" => tool_set_status(state, &args),
+        "clux_request_task" => tool_request_task(state, &args),
+        _ => Err(format!("Unknown tool: {tool_name}")),
+    };
+
+    match result {
+        Ok(content) => JsonRpcResponse::success(
+            req.id.clone(),
+            serde_json::json!({
+                "content": [{
+                    "type": "text",
+                    "text": content
+                }]
+            }),
+        ),
+        Err(e) => JsonRpcResponse::success(
+            req.id.clone(),
+            serde_json::json!({
+                "content": [{
+                    "type": "text",
+                    "text": e
+                }],
+                "isError": true
+            }),
+        ),
+    }
+}
+
+// --- Tool implementations ---
+
+fn tool_list_peers(state: &McpState) -> std::result::Result<String, String> {
+    let peers = state.broker.list_peers(None).map_err(|e| e.to_string())?;
+    serde_json::to_string_pretty(&peers).map_err(|e| e.to_string())
+}
+
+fn tool_send_message(
+    state: &McpState,
+    args: &serde_json::Value,
+) -> std::result::Result<String, String> {
+    let from = args
+        .get("from_peer")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing 'from_peer'")?;
+    let to = args
+        .get("to_peer")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing 'to_peer'")?;
+    let message = args.get("message").ok_or("Missing 'message'")?;
+
+    let msg = PeerMessage {
+        id: None,
+        from_peer: from.to_string(),
+        to_peer: Some(to.to_string()),
+        body: message.clone(),
+        timestamp: None,
+    };
+    let id = state.broker.send_message(&msg).map_err(|e| e.to_string())?;
+    Ok(format!("Message sent (id: {id})"))
+}
+
+fn tool_read_messages(
+    state: &McpState,
+    args: &serde_json::Value,
+) -> std::result::Result<String, String> {
+    let peer_id = args
+        .get("peer_id")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing 'peer_id'")?;
+    let since = args.get("since_id").and_then(serde_json::Value::as_i64);
+
+    let messages = state
+        .broker
+        .read_messages(peer_id, since)
+        .map_err(|e| e.to_string())?;
+    serde_json::to_string_pretty(&messages).map_err(|e| e.to_string())
+}
+
+fn tool_broadcast(
+    state: &McpState,
+    args: &serde_json::Value,
+) -> std::result::Result<String, String> {
+    let from = args
+        .get("from_peer")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing 'from_peer'")?;
+    let message = args.get("message").ok_or("Missing 'message'")?;
+
+    let id = state
+        .broker
+        .broadcast(from, message)
+        .map_err(|e| e.to_string())?;
+    Ok(format!("Broadcast sent (id: {id})"))
+}
+
+async fn tool_get_pane_context(
+    state: &McpState,
+    args: &serde_json::Value,
+) -> std::result::Result<String, String> {
+    let pane_id = args
+        .get("pane_id")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or("Missing or invalid 'pane_id'")?;
+
+    let contexts = state.pane_contexts.read().await;
+    match contexts.get(&pane_id) {
+        Some(text) => Ok(text.clone()),
+        None => Err(format!("No context available for pane {pane_id}")),
+    }
+}
+
+fn tool_set_status(
+    state: &McpState,
+    args: &serde_json::Value,
+) -> std::result::Result<String, String> {
+    let peer_id = args
+        .get("peer_id")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing 'peer_id'")?;
+    let text = args
+        .get("text")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing 'text'")?;
+
+    state
+        .broker
+        .set_status(peer_id, text)
+        .map_err(|e| e.to_string())?;
+    Ok(format!("Status updated for {peer_id}"))
+}
+
+fn tool_request_task(
+    state: &McpState,
+    args: &serde_json::Value,
+) -> std::result::Result<String, String> {
+    let from = args
+        .get("from_peer")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing 'from_peer'")?;
+    let description = args
+        .get("description")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing 'description'")?;
+    let assignee = args.get("assignee").and_then(|v| v.as_str());
+
+    let task = TaskRequest {
+        id: None,
+        description: description.to_string(),
+        status: if assignee.is_some() {
+            TaskStatus::Assigned
+        } else {
+            TaskStatus::Pending
+        },
+        requester: from.to_string(),
+        assignee: assignee.map(String::from),
+        created_at: None,
+    };
+    let id = state.broker.create_task(&task).map_err(|e| e.to_string())?;
+    Ok(format!("Task created (id: {id})"))
+}
+
+// --- Tool definitions ---
+
+fn build_tool_definitions() -> Vec<McpToolInfo> {
+    vec![
+        McpToolInfo {
+            name: "clux_list_peers".into(),
+            description: "List all active Claude Code panes in the terminal multiplexer".into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {},
+                "required": []
+            }),
+        },
+        McpToolInfo {
+            name: "clux_send_message".into(),
+            description: "Send a structured message to another Claude Code pane".into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "from_peer": { "type": "string", "description": "Your peer ID" },
+                    "to_peer": { "type": "string", "description": "Target peer ID" },
+                    "message": { "description": "Message content (any JSON value)" }
+                },
+                "required": ["from_peer", "to_peer", "message"]
+            }),
+        },
+        McpToolInfo {
+            name: "clux_read_messages".into(),
+            description: "Read messages sent to you, optionally since a given message ID".into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "peer_id": { "type": "string", "description": "Your peer ID" },
+                    "since_id": { "type": "integer", "description": "Only return messages after this ID" }
+                },
+                "required": ["peer_id"]
+            }),
+        },
+        McpToolInfo {
+            name: "clux_broadcast".into(),
+            description: "Broadcast a message to all Claude Code panes".into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "from_peer": { "type": "string", "description": "Your peer ID" },
+                    "message": { "description": "Message content (any JSON value)" }
+                },
+                "required": ["from_peer", "message"]
+            }),
+        },
+        McpToolInfo {
+            name: "clux_get_pane_context".into(),
+            description: "Get the visible terminal content of another pane (read-only)".into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "pane_id": { "type": "integer", "description": "Target pane ID" }
+                },
+                "required": ["pane_id"]
+            }),
+        },
+        McpToolInfo {
+            name: "clux_set_status".into(),
+            description: "Set your status text displayed in the status bar".into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "peer_id": { "type": "string", "description": "Your peer ID" },
+                    "text": { "type": "string", "description": "Status text to display" }
+                },
+                "required": ["peer_id", "text"]
+            }),
+        },
+        McpToolInfo {
+            name: "clux_request_task".into(),
+            description: "Request another agent to perform a task".into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "from_peer": { "type": "string", "description": "Your peer ID" },
+                    "description": { "type": "string", "description": "Task description" },
+                    "assignee": { "type": "string", "description": "Peer ID to assign the task to (optional)" }
+                },
+                "required": ["from_peer", "description"]
+            }),
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_state() -> Arc<McpState> {
+        Arc::new(McpState {
+            broker: Arc::new(Broker::in_memory().unwrap()),
+            pane_contexts: RwLock::new(HashMap::new()),
+        })
+    }
+
+    #[tokio::test]
+    async fn initialize_response() {
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            id: serde_json::json!(1),
+            method: "initialize".into(),
+            params: serde_json::Value::Null,
+        };
+        let resp = handle_initialize(&req);
+        assert!(resp.result.is_some());
+        let result = resp.result.unwrap();
+        assert_eq!(result["serverInfo"]["name"], "clux-coord");
+    }
+
+    #[tokio::test]
+    async fn tools_list_has_all_tools() {
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            id: serde_json::json!(1),
+            method: "tools/list".into(),
+            params: serde_json::Value::Null,
+        };
+        let resp = handle_tools_list(&req);
+        let tools = resp.result.unwrap()["tools"].as_array().unwrap().clone();
+        assert_eq!(tools.len(), 7);
+        let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
+        assert!(names.contains(&"clux_list_peers"));
+        assert!(names.contains(&"clux_send_message"));
+        assert!(names.contains(&"clux_read_messages"));
+        assert!(names.contains(&"clux_broadcast"));
+        assert!(names.contains(&"clux_get_pane_context"));
+        assert!(names.contains(&"clux_set_status"));
+        assert!(names.contains(&"clux_request_task"));
+    }
+
+    #[test]
+    fn tool_list_peers_empty() {
+        let state = test_state();
+        let result = tool_list_peers(&state).unwrap();
+        let peers: Vec<serde_json::Value> = serde_json::from_str(&result).unwrap();
+        assert!(peers.is_empty());
+    }
+
+    #[test]
+    fn tool_send_and_read_message() {
+        let state = test_state();
+        state.broker.register_peer("a", 0).unwrap();
+        state.broker.register_peer("b", 1).unwrap();
+
+        let args = serde_json::json!({
+            "from_peer": "a",
+            "to_peer": "b",
+            "message": {"text": "hello"}
+        });
+        tool_send_message(&state, &args).unwrap();
+
+        let read_args = serde_json::json!({ "peer_id": "b" });
+        let result = tool_read_messages(&state, &read_args).unwrap();
+        let msgs: Vec<serde_json::Value> = serde_json::from_str(&result).unwrap();
+        assert_eq!(msgs.len(), 1);
+    }
+
+    #[test]
+    fn tool_broadcast_message() {
+        let state = test_state();
+        state.broker.register_peer("a", 0).unwrap();
+
+        let args = serde_json::json!({
+            "from_peer": "a",
+            "message": "hello all"
+        });
+        let result = tool_broadcast(&state, &args).unwrap();
+        assert!(result.contains("Broadcast sent"));
+    }
+
+    #[tokio::test]
+    async fn tool_get_pane_context_found() {
+        let state = test_state();
+        state
+            .pane_contexts
+            .write()
+            .await
+            .insert(0, "$ ls\nfoo bar".into());
+
+        let args = serde_json::json!({ "pane_id": 0 });
+        let result = tool_get_pane_context(&state, &args).await.unwrap();
+        assert!(result.contains("$ ls"));
+    }
+
+    #[tokio::test]
+    async fn tool_get_pane_context_not_found() {
+        let state = test_state();
+        let args = serde_json::json!({ "pane_id": 99 });
+        let result = tool_get_pane_context(&state, &args).await;
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn tool_set_status_ok() {
+        let state = test_state();
+        state.broker.register_peer("a", 0).unwrap();
+
+        let args = serde_json::json!({ "peer_id": "a", "text": "building" });
+        let result = tool_set_status(&state, &args).unwrap();
+        assert!(result.contains("Status updated"));
+    }
+
+    #[test]
+    fn tool_request_task_ok() {
+        let state = test_state();
+        let args = serde_json::json!({
+            "from_peer": "a",
+            "description": "run cargo test",
+            "assignee": "b"
+        });
+        let result = tool_request_task(&state, &args).unwrap();
+        assert!(result.contains("Task created"));
+    }
+
+    #[tokio::test]
+    async fn unknown_method_returns_error() {
+        let state = test_state();
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            id: serde_json::json!(1),
+            method: "unknown/method".into(),
+            params: serde_json::Value::Null,
+        };
+        let Json(resp) = handle_mcp_request(axum::extract::State(state), Json(req)).await;
+        assert!(resp.error.is_some());
+        assert_eq!(resp.error.unwrap().code, -32601);
+    }
+}

--- a/crates/clux-coord/src/panel.rs
+++ b/crates/clux-coord/src/panel.rs
@@ -1,0 +1,235 @@
+use std::sync::Arc;
+
+use crate::broker::Broker;
+use crate::protocol::{PeerInfo, PeerMessage, TaskRequest};
+
+/// Data model for the coordination panel overlay.
+#[derive(Debug, Default)]
+pub struct CoordPanelData {
+    pub peers: Vec<PeerInfo>,
+    pub recent_messages: Vec<PeerMessage>,
+    pub tasks: Vec<TaskRequest>,
+}
+
+/// Manages the coordination panel state.
+pub struct CoordPanel {
+    broker: Arc<Broker>,
+    /// Whether the panel is currently visible.
+    pub visible: bool,
+    /// Cached panel data, refreshed on toggle or periodically.
+    pub data: CoordPanelData,
+}
+
+impl CoordPanel {
+    pub fn new(broker: Arc<Broker>) -> Self {
+        Self {
+            broker,
+            visible: false,
+            data: CoordPanelData::default(),
+        }
+    }
+
+    /// Toggle panel visibility. Refreshes data when opening.
+    pub fn toggle(&mut self) {
+        self.visible = !self.visible;
+        if self.visible {
+            self.refresh();
+        }
+    }
+
+    /// Refresh panel data from the broker.
+    pub fn refresh(&mut self) {
+        self.data.peers = self.broker.list_peers(None).unwrap_or_default();
+        // Read recent broadcast messages (last 50)
+        self.data.recent_messages = self
+            .broker
+            .read_messages("__panel__", None)
+            .unwrap_or_default()
+            .into_iter()
+            .rev()
+            .take(50)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect();
+        self.data.tasks = self.broker.list_tasks(None).unwrap_or_default();
+    }
+
+    /// Render the panel as a text block for display.
+    /// Returns lines of text to render as an overlay.
+    pub fn render_text(&self, max_width: usize) -> Vec<String> {
+        if !self.visible {
+            return Vec::new();
+        }
+
+        let mut lines = Vec::new();
+        let separator: String = "\u{2500}".repeat(max_width.min(60));
+
+        lines.push(format!("\u{250c}{separator}\u{2510}"));
+        lines.push(format!(
+            "\u{2502}{:^w$}\u{2502}",
+            "Coordination Panel",
+            w = separator.len()
+        ));
+        lines.push(format!("\u{251c}{separator}\u{2524}"));
+
+        // Peers section
+        lines.push(format!(
+            "\u{2502}{:^w$}\u{2502}",
+            "Peers",
+            w = separator.len()
+        ));
+        lines.push(format!("\u{251c}{separator}\u{2524}"));
+        if self.data.peers.is_empty() {
+            lines.push(format!(
+                "\u{2502}{:<w$}\u{2502}",
+                " No active peers",
+                w = separator.len()
+            ));
+        } else {
+            for peer in &self.data.peers {
+                let status = peer.status_text.as_deref().unwrap_or("idle");
+                let line = format!(" {} (pane {}) - {}", peer.peer_id, peer.pane_id, status);
+                let truncated = if line.len() > separator.len() {
+                    format!("{}\u{2026}", &line[..separator.len() - 1])
+                } else {
+                    line
+                };
+                lines.push(format!(
+                    "\u{2502}{:<w$}\u{2502}",
+                    truncated,
+                    w = separator.len()
+                ));
+            }
+        }
+
+        // Tasks section
+        lines.push(format!("\u{251c}{separator}\u{2524}"));
+        lines.push(format!(
+            "\u{2502}{:^w$}\u{2502}",
+            "Tasks",
+            w = separator.len()
+        ));
+        lines.push(format!("\u{251c}{separator}\u{2524}"));
+        if self.data.tasks.is_empty() {
+            lines.push(format!(
+                "\u{2502}{:<w$}\u{2502}",
+                " No tasks",
+                w = separator.len()
+            ));
+        } else {
+            for task in &self.data.tasks {
+                let line = format!(" [{}] {}", task.status, task.description);
+                let truncated = if line.len() > separator.len() {
+                    format!("{}\u{2026}", &line[..separator.len() - 1])
+                } else {
+                    line
+                };
+                lines.push(format!(
+                    "\u{2502}{:<w$}\u{2502}",
+                    truncated,
+                    w = separator.len()
+                ));
+            }
+        }
+
+        // Messages section
+        lines.push(format!("\u{251c}{separator}\u{2524}"));
+        lines.push(format!(
+            "\u{2502}{:^w$}\u{2502}",
+            "Recent Messages",
+            w = separator.len()
+        ));
+        lines.push(format!("\u{251c}{separator}\u{2524}"));
+        let recent: Vec<_> = self.data.recent_messages.iter().rev().take(10).collect();
+        if recent.is_empty() {
+            lines.push(format!(
+                "\u{2502}{:<w$}\u{2502}",
+                " No messages",
+                w = separator.len()
+            ));
+        } else {
+            for msg in recent.iter().rev() {
+                let to = msg.to_peer.as_deref().unwrap_or("all");
+                let body_preview = msg.body.to_string();
+                let line = format!(" {} \u{2192} {}: {}", msg.from_peer, to, body_preview);
+                let truncated = if line.len() > separator.len() {
+                    format!("{}\u{2026}", &line[..separator.len() - 1])
+                } else {
+                    line
+                };
+                lines.push(format!(
+                    "\u{2502}{:<w$}\u{2502}",
+                    truncated,
+                    w = separator.len()
+                ));
+            }
+        }
+
+        lines.push(format!("\u{2514}{separator}\u{2518}"));
+        lines
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_panel() -> CoordPanel {
+        let broker = Arc::new(Broker::in_memory().unwrap());
+        CoordPanel::new(broker)
+    }
+
+    #[test]
+    fn panel_starts_hidden() {
+        let panel = test_panel();
+        assert!(!panel.visible);
+        assert!(panel.render_text(60).is_empty());
+    }
+
+    #[test]
+    fn toggle_shows_and_hides() {
+        let mut panel = test_panel();
+        panel.toggle();
+        assert!(panel.visible);
+        assert!(!panel.render_text(60).is_empty());
+        panel.toggle();
+        assert!(!panel.visible);
+        assert!(panel.render_text(60).is_empty());
+    }
+
+    #[test]
+    fn panel_shows_peers() {
+        let broker = Arc::new(Broker::in_memory().unwrap());
+        broker.register_peer("p1", 0).unwrap();
+        broker.set_status("p1", "testing").unwrap();
+
+        let mut panel = CoordPanel::new(broker);
+        panel.toggle();
+
+        let text = panel.render_text(60).join("\n");
+        assert!(text.contains("p1"));
+        assert!(text.contains("testing"));
+    }
+
+    #[test]
+    fn panel_shows_tasks() {
+        let broker = Arc::new(Broker::in_memory().unwrap());
+        let task = crate::protocol::TaskRequest {
+            id: None,
+            description: "run tests".into(),
+            status: crate::protocol::TaskStatus::Pending,
+            requester: "a".into(),
+            assignee: None,
+            created_at: None,
+        };
+        broker.create_task(&task).unwrap();
+
+        let mut panel = CoordPanel::new(broker);
+        panel.toggle();
+
+        let text = panel.render_text(60).join("\n");
+        assert!(text.contains("run tests"));
+        assert!(text.contains("pending"));
+    }
+}

--- a/crates/clux-coord/src/peer.rs
+++ b/crates/clux-coord/src/peer.rs
@@ -1,0 +1,90 @@
+use std::sync::Arc;
+
+use crate::broker::Broker;
+use crate::error::Result;
+use crate::protocol::PeerInfo;
+
+/// Maximum age (seconds) before a peer is considered stale.
+const PEER_TIMEOUT_SECS: i64 = 120;
+
+/// Manages peer lifecycle (registration, heartbeat, discovery).
+pub struct PeerManager {
+    broker: Arc<Broker>,
+}
+
+impl PeerManager {
+    pub fn new(broker: Arc<Broker>) -> Self {
+        Self { broker }
+    }
+
+    /// Register a new peer for the given pane.
+    pub fn register(&self, peer_id: &str, pane_id: u64) -> Result<()> {
+        self.broker.register_peer(peer_id, pane_id)
+    }
+
+    /// Unregister a peer when a pane is closed.
+    pub fn unregister(&self, peer_id: &str) -> Result<()> {
+        self.broker.unregister_peer(peer_id)
+    }
+
+    /// Update heartbeat for a peer.
+    pub fn heartbeat(&self, peer_id: &str) -> Result<()> {
+        self.broker.heartbeat(peer_id)
+    }
+
+    /// List active peers (within timeout window).
+    pub fn list_active(&self) -> Result<Vec<PeerInfo>> {
+        self.broker.list_peers(Some(PEER_TIMEOUT_SECS))
+    }
+
+    /// List all registered peers regardless of heartbeat.
+    pub fn list_all(&self) -> Result<Vec<PeerInfo>> {
+        self.broker.list_peers(None)
+    }
+
+    /// Set status text displayed in the status bar.
+    pub fn set_status(&self, peer_id: &str, text: &str) -> Result<()> {
+        self.broker.set_status(peer_id, text)
+    }
+
+    /// Set current working directory for a peer.
+    pub fn set_cwd(&self, peer_id: &str, cwd: &str) -> Result<()> {
+        self.broker.set_cwd(peer_id, cwd)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_manager() -> PeerManager {
+        let broker = Arc::new(Broker::in_memory().unwrap());
+        PeerManager::new(broker)
+    }
+
+    #[test]
+    fn register_and_list() {
+        let pm = test_manager();
+        pm.register("p1", 0).unwrap();
+        pm.register("p2", 1).unwrap();
+        let peers = pm.list_all().unwrap();
+        assert_eq!(peers.len(), 2);
+    }
+
+    #[test]
+    fn unregister_removes_peer() {
+        let pm = test_manager();
+        pm.register("p1", 0).unwrap();
+        pm.unregister("p1").unwrap();
+        assert!(pm.list_all().unwrap().is_empty());
+    }
+
+    #[test]
+    fn status_update() {
+        let pm = test_manager();
+        pm.register("p1", 0).unwrap();
+        pm.set_status("p1", "compiling").unwrap();
+        let peers = pm.list_all().unwrap();
+        assert_eq!(peers[0].status_text.as_deref(), Some("compiling"));
+    }
+}

--- a/crates/clux-coord/src/protocol.rs
+++ b/crates/clux-coord/src/protocol.rs
@@ -1,0 +1,184 @@
+use serde::{Deserialize, Serialize};
+
+/// Unique identifier for a pane/peer in the coordination system.
+pub type PeerId = String;
+
+/// Information about a registered peer (Claude Code instance in a pane).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PeerInfo {
+    pub peer_id: PeerId,
+    pub pane_id: u64,
+    pub cwd: Option<String>,
+    pub status_text: Option<String>,
+    pub last_heartbeat: i64,
+}
+
+/// A message sent between peers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PeerMessage {
+    pub id: Option<i64>,
+    pub from_peer: PeerId,
+    pub to_peer: Option<PeerId>,
+    pub body: serde_json::Value,
+    pub timestamp: Option<i64>,
+}
+
+/// A task request that one agent can assign to another.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskRequest {
+    pub id: Option<i64>,
+    pub description: String,
+    pub status: TaskStatus,
+    pub requester: PeerId,
+    pub assignee: Option<PeerId>,
+    pub created_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskStatus {
+    Pending,
+    Assigned,
+    InProgress,
+    Completed,
+    Failed,
+}
+
+impl std::fmt::Display for TaskStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pending => write!(f, "pending"),
+            Self::Assigned => write!(f, "assigned"),
+            Self::InProgress => write!(f, "in_progress"),
+            Self::Completed => write!(f, "completed"),
+            Self::Failed => write!(f, "failed"),
+        }
+    }
+}
+
+impl std::str::FromStr for TaskStatus {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "pending" => Ok(Self::Pending),
+            "assigned" => Ok(Self::Assigned),
+            "in_progress" => Ok(Self::InProgress),
+            "completed" => Ok(Self::Completed),
+            "failed" => Ok(Self::Failed),
+            _ => Err(format!("unknown task status: {s}")),
+        }
+    }
+}
+
+/// MCP JSON-RPC 2.0 request envelope.
+#[derive(Debug, Deserialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: String,
+    pub id: serde_json::Value,
+    pub method: String,
+    #[serde(default)]
+    pub params: serde_json::Value,
+}
+
+/// MCP JSON-RPC 2.0 response envelope.
+#[derive(Debug, Serialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: String,
+    pub id: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+}
+
+impl JsonRpcResponse {
+    pub fn success(id: serde_json::Value, result: serde_json::Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub fn error(id: serde_json::Value, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: None,
+            error: Some(JsonRpcError {
+                code,
+                message: message.into(),
+            }),
+        }
+    }
+}
+
+/// MCP tool description for the `tools/list` response.
+#[derive(Debug, Serialize)]
+pub struct McpToolInfo {
+    pub name: String,
+    pub description: String,
+    #[serde(rename = "inputSchema")]
+    pub input_schema: serde_json::Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_status_roundtrip() {
+        for status in [
+            TaskStatus::Pending,
+            TaskStatus::Assigned,
+            TaskStatus::InProgress,
+            TaskStatus::Completed,
+            TaskStatus::Failed,
+        ] {
+            let s = status.to_string();
+            let parsed: TaskStatus = s.parse().unwrap();
+            assert_eq!(parsed, status);
+        }
+    }
+
+    #[test]
+    fn json_rpc_response_success_serialization() {
+        let resp =
+            JsonRpcResponse::success(serde_json::json!(1), serde_json::json!({"status": "ok"}));
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["jsonrpc"], "2.0");
+        assert_eq!(json["result"]["status"], "ok");
+        assert!(json.get("error").is_none());
+    }
+
+    #[test]
+    fn json_rpc_response_error_serialization() {
+        let resp = JsonRpcResponse::error(serde_json::json!(2), -32601, "Method not found");
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["error"]["code"], -32601);
+        assert!(json.get("result").is_none());
+    }
+
+    #[test]
+    fn peer_message_serialization() {
+        let msg = PeerMessage {
+            id: None,
+            from_peer: "peer-1".into(),
+            to_peer: Some("peer-2".into()),
+            body: serde_json::json!({"text": "hello"}),
+            timestamp: None,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: PeerMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.from_peer, "peer-1");
+        assert_eq!(parsed.to_peer.as_deref(), Some("peer-2"));
+    }
+}


### PR DESCRIPTION
## Summary
- happy-ryo/clux から clux-coord crate を移植
- SQLite バックエンドメッセージブローカー (peers/messages/tasks テーブル)
- MCP JSON-RPC 2.0 HTTP サーバー (7 ツール: list_peers, send_message, read_messages, broadcast, get_pane_context, set_status, request_task)
- Claude Code 検出 + MCP config 自動注入
- 協調パネルデータモデル
- PeerManager (ピアライフサイクル管理)

## Test plan
- [x] `cargo build -p clux-coord` 成功
- [x] `cargo test -p clux-coord` — 36 テスト全パス
- [x] `cargo +nightly fmt` パス
- [x] 全ワークスペースビルド成功

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)